### PR TITLE
CarbonReader and NutrientsReader can accept a different path for data

### DIFF
--- a/static/Carbon_reader.py
+++ b/static/Carbon_reader.py
@@ -1,16 +1,26 @@
+from os import PathLike
+from pathlib import Path
+from typing import Union
 
 from commons.time_interval import TimeInterval
 from basins.region import Rectangle
 from static.DatasetExtractor import DatasetExtractor
 from commons.utils import find_index
 
+
+DEFAULT_FILENAME = Path(
+    "/gss/gss_work/DRES_OGS_BiGe/Observations/TIME_RAW_DATA/STATIC/"
+    "Carbon/Dataset_Med_CarbSys_RIC.nc"
+)
+
+
 class CarbonReader(DatasetExtractor):
     
-    def __init__(self):
+    def __init__(self, filename: Union[str, PathLike] = DEFAULT_FILENAME):
         '''
         Reads the NetCDF Dataset
         '''
-        self.filename="/gss/gss_work/DRES_OGS_BiGe/Observations/TIME_RAW_DATA/STATIC/Carbon/Dataset_Med_CarbSys_RIC.nc"
+        self.filename = filename
         self.DataExtractor = DatasetExtractor(self.filename,'Carbon')
 
         # DATA ELIMINATION in order to not duplicate values with nutrients dataset
@@ -109,7 +119,7 @@ class CarbonReader(DatasetExtractor):
 
 if __name__ == '__main__':
     
-    var= 'nitrate';
+    var= 'nitrate'
     TI = TimeInterval('19900101','2005101','%Y%m%d')
     Reg= Rectangle(-6,36,30,46)
     C = CarbonReader()

--- a/static/Carbon_reader.py
+++ b/static/Carbon_reader.py
@@ -15,6 +15,11 @@ DEFAULT_FILENAME = Path(
 
 
 class CarbonReader(DatasetExtractor):
+
+    DATA_VARS = (
+        'nitrate', 'phosphate', 'oxygen', 'silicate', 'DIC', 'ALK', 'temp',
+        'salinity', 'pH25_T', 'xCO2', 'pCO2'
+    )
     
     def __init__(self, filename: Union[str, PathLike] = DEFAULT_FILENAME):
         '''
@@ -109,7 +114,7 @@ class CarbonReader(DatasetExtractor):
 
         if var is None:
             Profilelist = list()
-            for myvar in ['nitrate','phosphate','oxygen','silicate','DIC','ALK','temp','salinity','pH25_T','xCO2','pCO2']:
+            for myvar in self.DATA_VARS:
                 Profilelist.extend(self.DataExtractor.selector(myvar, T_int, region))
             return Profilelist
         return self.DataExtractor.selector(var, T_int, region)

--- a/static/Nutrients_reader.py
+++ b/static/Nutrients_reader.py
@@ -16,6 +16,12 @@ DEFAULT_FILENAME = Path(
 
 
 class NutrientsReader():
+
+    DATA_VARS = (
+        'nitrate', 'phosphate', 'silicate', 'oxygen', 'nitrite', 'ammonium',
+        'chlorophyll', 'total_chlorophyll'
+    )
+
     def __init__(self, filename: Union[str, PathLike] = DEFAULT_FILENAME):
         '''
         Reads the NetCDF Dataset
@@ -121,7 +127,7 @@ class NutrientsReader():
          '''
         if var is None:
             Profilelist=list()
-            for myvar in ['nitrate','phosphate','silicate','oxygen','nitrite','ammonium','chlorophyll','total_chlorophyll']:
+            for myvar in self.DATA_VARS:
                 sublist=self.DataExtractor.selector(myvar, T_int, region)
                 for p in sublist: 
                     if not p in Profilelist: Profilelist.append(p)

--- a/static/Nutrients_reader.py
+++ b/static/Nutrients_reader.py
@@ -1,3 +1,6 @@
+from os import PathLike
+from pathlib import Path
+from typing import Union
 
 from commons.time_interval import TimeInterval
 from basins.region import Rectangle
@@ -5,15 +8,19 @@ from static.DatasetExtractor import DatasetExtractor
 import numpy as np
 from commons.utils import find_index
 
+
+DEFAULT_FILENAME = Path(
+    "/gss/gss_work/DRES_OGS_BiGe/Observations/TIME_RAW_DATA/STATIC/"
+    "Nutrients/Dataset_Med_Nutrients.nc"
+)
+
+
 class NutrientsReader():
-    
-    
-    
-    def __init__(self):
+    def __init__(self, filename: Union[str, PathLike] = DEFAULT_FILENAME):
         '''
         Reads the NetCDF Dataset
         '''
-        self.filename="/gss/gss_work/DRES_OGS_BiGe/Observations/TIME_RAW_DATA/STATIC/Nutrients/Dataset_Med_Nutrients.nc"
+        self.filename = filename
         self.DataExtractor = DatasetExtractor(self.filename, 'Nutrients')
 
         # QC  section ----------------


### PR DESCRIPTION
This pull request enhances the interface of the CarbonReader and NutrientsReader classes. Their constructors now permit the specification of the dataset path to be read. If this path is not provided, the code defaults to the previous behavior, utilizing the default path.

Additionally, the pull request addresses a bug in the RegionIntersection class implemented for the CADEAU basins and removes a deprecated np.bool_ in the EmptyRegion class.