### PR TITLE
Adding a CLI option to avoid to compute averages for files that are too recent

### DIFF
--- a/Sat/SatManager.py
+++ b/Sat/SatManager.py
@@ -8,6 +8,7 @@ import os
 
 def mean(array):
     return array.mean()
+
 def logmean(array):
     LOGmean= np.log(array).mean()
     return np.exp(LOGmean)

--- a/Sat/aveSat.py
+++ b/Sat/aveSat.py
@@ -1,4 +1,6 @@
 import argparse
+from utilities.argparse_types import date_from_str
+
 def argument():
     parser = argparse.ArgumentParser(description = '''
     Generic averager for sat files.
@@ -50,6 +52,14 @@ def argument():
                                 action='store_true',
                                 help = """Overwrite existing variables in files
                                 """)
+
+    parser.add_argument(   '--ignore-after', '-a',
+                                type = date_from_str,
+                                required = False,
+                                default = None,
+                                help = "Ignore all input files with dates later than the one submitted here"
+                                )
+
     return parser.parse_args()
 
 args = argument()
@@ -57,6 +67,7 @@ args = argument()
 
 from commons.Timelist import TimeList
 from commons.time_interval import TimeInterval
+from datetime import datetime
 from postproc import masks
 import numpy as np
 import os
@@ -79,10 +90,13 @@ DIRDATES = addsep(args.dirdates)
 maskSat = getattr(masks,args.mesh)
 
 
+Timestart = datetime.strptime("19500101", "%Y%m%d")
+Time__end = datetime.strptime("20500101", "%Y%m%d")
 
-Timestart="19500101"
-Time__end="20500101"
-TI = TimeInterval(Timestart,Time__end,"%Y%m%d")
+if args.ignore_after is not None:
+    Time__end = args.ignore_after
+
+TI = TimeInterval.fromdatetimes(Timestart, Time__end)
 TLCheck = TimeList.fromfilenames(TI, CHECKDIR,"*.nc",prefix='',dateformat='%Y%m%d')
 suffix = os.path.basename(TLCheck.filelist[0])[8:]
 

--- a/commons/time_interval.py
+++ b/commons/time_interval.py
@@ -1,9 +1,10 @@
-import datetime
+from datetime import datetime
 
-class TimeInterval():
-    def __init__(self, starttime="19500101", endtime="21000101", dateformat='%Y%m%d'):
-        self.start_time = datetime.datetime.strptime(starttime, dateformat)
-        self.end_time = datetime.datetime.strptime(endtime   ,dateformat)
+
+class TimeInterval:
+    def __init__(self, starttime: str = "19500101", endtime: str = "21000101", dateformat: str ='%Y%m%d'):
+        self.start_time = datetime.strptime(starttime, dateformat)
+        self.end_time = datetime.strptime(endtime   ,dateformat)
         assert self.start_time <= self.end_time
     
     def __repr__(self):
@@ -64,7 +65,7 @@ class TimeInterval():
         return res
     
     @staticmethod
-    def fromdatetimes(timestart,time_end):
+    def fromdatetimes(timestart: datetime, time_end: datetime):
         '''
         Arguments:
         * timestart * a datetime object

--- a/utilities/argparse_types.py
+++ b/utilities/argparse_types.py
@@ -66,7 +66,10 @@ def non_existing_path_inside_an_existing_dir(arg_path: str) -> Path:
 
 
 def date_from_str(arg_path: str) -> datetime:
-    formats = ('%Y-%m-%d', '%Y-%m-%dT%H:%M', '%Y-%m-%dT%H:%M:%S')
+    formats = (
+        '%Y%m%d', '%Y%m%d-%H:%M', '%Y%m%d-%H:%M:%S',
+        '%Y-%m-%d', '%Y-%m-%dT%H:%M', '%Y-%m-%dT%H:%M:%S'
+    )
 
     output_date = None
     for date_format in formats:


### PR DESCRIPTION
This pull request adds a command line option to the `aveSat.py` and `aveSat_kd.py` scripts, enabling the option to ignore more recent files. This prevents the computation of averages for time intervals for which all the data is not yet available.