### PR TITLE
relax instance check

### DIFF
--- a/src/bitsea/commons/dataextractor.py
+++ b/src/bitsea/commons/dataextractor.py
@@ -112,9 +112,6 @@ class DataExtractor(object):
             self.__filename = fn
             self.__varname = v
 
-        if not isinstance(mask, (Mask,)):
-            raise ValueError("mask must be a Mask object")
-
         #test dimensions
         if self.dims==3:
             if self.__shape[1:] != mask.shape[1:]:


### PR DESCRIPTION
Remove checking that variable is an instance of Mask.
This instance check was causing problems in MER, where we have a vendored and refactored version of Mask, which is duck-typing-compatible with bitsea.commons.mask.Mask but for python's type system is considered as a different type.