### PR TITLE
29 sat scripts should have as arguments filelists instead of dirs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,7 @@ pythonpath = ["src"]
 markers = [
     "uses_test_data: Needs external data not downloaded from the repository"
 ]
+
+
+[tool.ruff.lint.pyflakes]
+allowed-unused-imports = ["mpi4py.MPI"]

--- a/src/bitsea/Sat/aveSat.py
+++ b/src/bitsea/Sat/aveSat.py
@@ -17,7 +17,7 @@ from bitsea.utilities.argparse_types import some_among
 from bitsea.utilities.mpi_serial_interface import get_mpi_communicator
 
 
-def configure_argparse():
+def argument():
     parser = argparse.ArgumentParser(
         description="""
     Generic averager for sat files.
@@ -239,7 +239,7 @@ def aveSat(
 
 
 def main():
-    args = configure_argparse()
+    args = argument()
 
     if not args.serial:
         # noinspection PyUnresolvedReferences

--- a/src/bitsea/Sat/aveSat.py
+++ b/src/bitsea/Sat/aveSat.py
@@ -1,200 +1,276 @@
 import argparse
-from bitsea.utilities.argparse_types import some_among, date_from_str, existing_dir_path
-
-def argument():
-    parser = argparse.ArgumentParser(description = '''
-    Generic averager for sat files.
-    It works with one mesh, without performing interpolations.
-    Empty dirdates is provided when the number of input daily files is lesser than 3.
-    ''',
-    formatter_class=argparse.ArgumentDefaultsHelpFormatter
-    )
-
-    parser.add_argument(   '--checkdir', '-i',
-                                type = existing_dir_path,
-                                required = True,
-                                help = ''' CHECKED sat directory, e.g. /gss/gss_work/DRES_OGS_BiGe/Observations/TIME_RAW_DATA/ONLINE/SAT/MODIS/DAILY/CHECKED/'''
-
-                                )
-    parser.add_argument(   '--outdir', '-o',
-                                type = existing_dir_path,
-                                required = True,
-                                help = ''' OUT average dates sat directory'''
-
-                                )
-
-    parser.add_argument(   '--mesh', '-m',
-                                type = str,
-                                required = True,
-                                choices = ['SatOrigMesh','V4mesh','V1mesh','KD490mesh','SAT1km_mesh', 'Mesh24', 'Mesh4'],
-                                help = ''' Name of the mesh of sat ORIG and used to dump checked data.'''
-                                )
-    parser.add_argument(   '--varnames', '-v',
-                                type = some_among(['CHL','KD490','DIATO','NANO','PICO', 'DINO','RRS412','RRS443','RRS490','RRS510','RRS555','RRS670']),
-                                required = True
-                                )
-
-    parser.add_argument(   '--timeaverage', '-t',
-                                type = str,
-                                required = True,
-                                choices = ['monthly','weekly_tuesday','weekly_friday','weekly_monday','weekly_thursday','tendays'],
-                                help = ''' Name of the mesh of sat ORIG and used to dump checked data.'''
-                                )
-    parser.add_argument(   '--ignore-after', '-a',
-                                type = date_from_str,
-                                required = False,
-                                default = None,
-                                help = "Ignore all input files with dates later than the one submitted here"
-                                )
-    parser.add_argument(   '--force', '-f',
-                                action='store_true',
-                                help = """Overwrite existing variables in files
-                                """)
-    parser.add_argument(   '--serial',
-                                action='store_true',
-                                help = '''Do not use mpi''')
-    return parser.parse_args()
-
-args = argument()
-
-from pathlib import Path
-from typing import List, Iterable
-from bitsea.commons.Timelist import TimeList
-from bitsea.commons.time_interval import TimeInterval
 from datetime import datetime
-from bitsea.postproc import masks
-import numpy as np
-import bitsea.Sat.SatManager as Sat
-from sys import exit
+from pathlib import Path
+from sys import exit as sys_exit
+from typing import List
+from typing import Sequence
 
+import bitsea.Sat.SatManager as Sat
+import numpy as np
+from bitsea.commons.time_interval import TimeInterval
+from bitsea.commons.Timelist import TimeList
+from bitsea.postproc import masks
+from bitsea.utilities.argparse_types import date_from_str
+from bitsea.utilities.argparse_types import existing_dir_path
+from bitsea.utilities.argparse_types import some_among
 from bitsea.utilities.mpi_serial_interface import get_mpi_communicator
 
 
-def aveSat(*,
-inputfiles: Iterable[Path],
-datetimes: List[str],
-outputdir: Path,
-mesh: str,
-varnames = List[str],
-serial : bool = False,
-outfrequency : str = "weekly",
-week_day : int = 1,
-force : bool,
-)-> List[Path]:
+def configure_argparse():
+    parser = argparse.ArgumentParser(
+        description="""
+    Generic averager for sat files.
+    It works with one mesh, without performing interpolations.
+    Empty dirdates is provided when the number of input daily files is lesser than 3.
+    """,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
 
-    assert outfrequency in ['monthly','weekly','ten_days']
-    assert week_day in range(7)
+    parser.add_argument(
+        "--checkdir",
+        "-i",
+        type=existing_dir_path,
+        required=True,
+        help=""" CHECKED sat directory, e.g. /gss/gss_work/DRES_OGS_BiGe/Observations/TIME_RAW_DATA/ONLINE/SAT/MODIS/DAILY/CHECKED/""",
+    )
+    parser.add_argument(
+        "--outdir",
+        "-o",
+        type=existing_dir_path,
+        required=True,
+        help=""" OUT average dates sat directory""",
+    )
 
-    if not serial:
-        import mpi4py.MPI
+    parser.add_argument(
+        "--mesh",
+        "-m",
+        type=str,
+        required=True,
+        choices=[
+            "SatOrigMesh",
+            "V4mesh",
+            "V1mesh",
+            "KD490mesh",
+            "SAT1km_mesh",
+            "Mesh24",
+            "Mesh4",
+        ],
+        help=""" Name of the mesh of sat ORIG and used to dump checked data.""",
+    )
+    parser.add_argument(
+        "--varnames",
+        "-v",
+        type=some_among(
+            [
+                "CHL",
+                "KD490",
+                "DIATO",
+                "NANO",
+                "PICO",
+                "DINO",
+                "RRS412",
+                "RRS443",
+                "RRS490",
+                "RRS510",
+                "RRS555",
+                "RRS670",
+            ]
+        ),
+        required=True,
+    )
 
+    parser.add_argument(
+        "--timeaverage",
+        "-t",
+        type=str,
+        required=True,
+        choices=[
+            "monthly",
+            "weekly_tuesday",
+            "weekly_friday",
+            "weekly_monday",
+            "weekly_thursday",
+            "tendays",
+        ],
+        help=""" Name of the mesh of sat ORIG and used to dump checked data.""",
+    )
+    parser.add_argument(
+        "--ignore-after",
+        "-a",
+        type=date_from_str,
+        required=False,
+        default=None,
+        help="Ignore all input files with dates later than the one submitted here",
+    )
+    parser.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        help="""Overwrite existing variables in files
+                                """,
+    )
+    parser.add_argument(
+        "--serial", action="store_true", help="""Do not use mpi"""
+    )
+    return parser.parse_args()
+
+
+def aveSat(
+    *,
+    inputfiles: Sequence[Path],
+    datetimes: List[datetime],
+    outputdir: Path,
+    mesh: str,
+    varnames: List[str],
+    outfrequency: str = "weekly",
+    week_day: int = 1,
+    force: bool = False,
+) -> List[Path]:
+    valid_frequencies = ("monthly", "weekly", "ten_days")
+    if outfrequency not in valid_frequencies:
+        raise ValueError(
+            f"outfrequency must be one among {valid_frequencies}; received {outfrequency}"
+        )
+    if week_day < 0 or week_day >= 7:
+        raise ValueError(
+            "week_day must be greater or equal than 0 and "
+            f"smaller than 7; received {week_day}"
+        )
+    if int(week_day) != week_day:
+        raise ValueError(
+            f"week_day must be an integer number: received {week_day}"
+        )
 
     comm = get_mpi_communicator()
-    rank  = comm.Get_rank()
-    nranks =comm.size
+    rank = comm.Get_rank()
+    nranks = comm.size
 
-    OUTDIR   = outputdir
-    maskSat = getattr(masks,mesh)
-
+    mask_sat = getattr(masks, mesh)
 
     suffix = inputfiles[0].name[8:]
     TLCheck = TimeList(datetimes)
-    if outfrequency == 'monthly'    : TIME_reqs=TLCheck.getMonthlist()
-    if outfrequency == "weekly"     : TIME_reqs=TLCheck.getWeeklyList(week_day)
-    if outfrequency == "ten_days"   : TIME_reqs=TLCheck.getSpecificIntervalList(10,"19971001-12:00:00")
+    if outfrequency == "monthly":
+        TIME_reqs = TLCheck.getMonthlist()
+    elif outfrequency == "weekly":
+        TIME_reqs = TLCheck.getWeeklyList(week_day)
+    elif outfrequency == "ten_days":
+        TIME_reqs = TLCheck.getSpecificIntervalList(10, "19971001-12:00:00")
+    else:
+        raise ValueError(
+            f'outfrequency must be one among "monthly", "weekly" or "ten_days"; received {outfrequency}'
+        )
 
-
-    jpi = maskSat.jpi
-    jpj = maskSat.jpj
-    averaged_filelist = [ OUTDIR / (req.string + suffix) for req in TIME_reqs ]
-
-
+    jpi = mask_sat.jpi
+    jpj = mask_sat.jpj
+    averaged_filelist = [outputdir / (req.string + suffix) for req in TIME_reqs]
 
     for req in TIME_reqs[rank::nranks]:
-
-        outfile = OUTDIR / (req.string + suffix)
+        outfile = outputdir / (req.string + suffix)
 
         ii, w = TLCheck.select(req)
-        nFiles = len(ii)
-        if nFiles < 3 :
+        n_files = len(ii)
+        if n_files < 3:
             print(req, "less than 3 files - Skipping average generation")
-            print(" ".join([TLCheck.Timelist[k].strftime("%Y%m%d") for k in ii]))
+            print(
+                " ".join([TLCheck.Timelist[k].strftime("%Y%m%d") for k in ii])
+            )
             continue
 
         for varname in varnames:
             writing_mode = Sat.writing_mode(outfile)
             if outfile.exists():
                 try:
-                    dateweek_string = Sat.read_variable_attribute(outfile,varname,'average_of')
-                except (AttributeError,IndexError):
+                    dateweek_string = Sat.read_variable_attribute(
+                        outfile, varname, "average_of"
+                    )
+                except (AttributeError, IndexError):
                     dateweek_string = ""
-                nDates=len(dateweek_string.split(","))
+                n_dates = len(dateweek_string.split(","))
 
-
-                if nFiles>nDates:
-                    pass #print('Not skipping ' + req.string + " for " + varname)
+                if n_files > n_dates:
+                    pass  # print('Not skipping ' + req.string + " for " + varname)
                 else:
-                    condition_to_write = not Sat.exist_valid_variable(varname,outfile)
-                    if force: condition_to_write=True
-                    if not condition_to_write: continue
-
+                    condition_to_write = not Sat.exist_valid_variable(
+                        varname, outfile
+                    )
+                    if force:
+                        condition_to_write = True
+                    if not condition_to_write:
+                        continue
 
             print(outfile, varname, flush=True)
             dateweek = []
 
-
-            M = np.zeros((nFiles,jpj,jpi),np.float32)
+            M = np.zeros((n_files, jpj, jpi), np.float32)
             for iFrame, j in enumerate(ii):
                 inputfile = inputfiles[j]
-                VALUES = Sat.readfromfile(inputfile, varname)
-                M[iFrame,:,:] = VALUES
+                frame_values = Sat.readfromfile(inputfile, varname)
+                M[iFrame, :, :] = frame_values
                 idate = datetimes[j]
-                date8 = idate.strftime('%Y%m%d')
+                date8 = idate.strftime("%Y%m%d")
                 dateweek.append(date8)
-            if varname == 'KD490':
-                OUT = Sat.averager(M)
+            if varname == "KD490":
+                output_data = Sat.averager(M)
             else:
-                OUT = Sat.logAverager(M)
-            dateweek_string=','.join(dateweek)
-            var_attributes={'average_of':dateweek_string}
-            Sat.dumpGenericfile(outfile, OUT, varname, mesh=maskSat, mode=writing_mode, var_attributes=var_attributes)
+                output_data = Sat.logAverager(M)
+            dateweek_string = ",".join(dateweek)
+            var_attributes = {"average_of": dateweek_string}
+            Sat.dumpGenericfile(
+                outfile,
+                output_data,
+                varname,
+                mesh=mask_sat,
+                mode=writing_mode,
+                var_attributes=var_attributes,
+            )
     return averaged_filelist
 
 
 def main():
-    args = argument()
+    args = configure_argparse()
 
-    Timestart = datetime.strptime("19500101", "%Y%m%d")
-    Time__end = datetime.strptime("20500101", "%Y%m%d")
+    if not args.serial:
+        # noinspection PyUnresolvedReferences
+        import mpi4py.MPI  # unused import
+
+    time_start = datetime.strptime("19500101", "%Y%m%d")
+    time_end = datetime.strptime("20500101", "%Y%m%d")
 
     if args.ignore_after is not None:
-        Time__end = args.ignore_after
+        time_end = args.ignore_after
 
-    TI = TimeInterval.fromdatetimes(Timestart, Time__end)
-    TL = TimeList.fromfilenames(TI, args.checkdir,"*.nc",prefix='',dateformat='%Y%m%d')
+    TI = TimeInterval.fromdatetimes(time_start, time_end)
+    TL = TimeList.fromfilenames(
+        TI, args.checkdir, "*.nc", prefix="", dateformat="%Y%m%d"
+    )
 
-    outfrequency = 'weekly'
+    out_frequency = "weekly"
     weekday = None
-    if args.timeaverage == 'monthly'        : outfrequency = 'monthly'
-    if args.timeaverage == 'weekly_tuesday' : weekday=2
-    if args.timeaverage == 'weekly_friday'  : weekday=5
-    if args.timeaverage == 'weekly_monday'  : weekday=1
-    if args.timeaverage == 'weekly_thursday': weekday=4
-    if args.timeaverage == 'tendays'        : outfrequency = 'tendays'
+    if args.timeaverage == "monthly":
+        out_frequency = "monthly"
+    if args.timeaverage == "weekly_tuesday":
+        weekday = 2
+    if args.timeaverage == "weekly_friday":
+        weekday = 5
+    if args.timeaverage == "weekly_monday":
+        weekday = 1
+    if args.timeaverage == "weekly_thursday":
+        weekday = 4
+    if args.timeaverage == "tendays":
+        out_frequency = "tendays"
 
     aveSat(
         inputfiles=TL.filelist,
-        datetimes = TL.Timelist,
+        datetimes=TL.Timelist,
         outputdir=args.outdir,
         mesh=args.mesh,
         varnames=args.varnames,
-        outfrequency=outfrequency,
-        week_day = weekday,
-        force = args.force,
-        serial=args.serial,
+        outfrequency=out_frequency,
+        week_day=weekday,
+        force=args.force,
     )
     return 0
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys_exit(main())

--- a/src/bitsea/Sat/aveSat.py
+++ b/src/bitsea/Sat/aveSat.py
@@ -82,6 +82,9 @@ week_day : int = 1,
 force : bool,
 )-> List[Path]:
 
+    assert outfrequency in ['monthly','weekly','ten_days']
+    assert week_day in range(7)
+
     if not serial:
         import mpi4py.MPI
 

--- a/src/bitsea/Sat/interpolator.py
+++ b/src/bitsea/Sat/interpolator.py
@@ -87,11 +87,10 @@ def argument():
         "--force",
         "-f",
         action="store_true",
-        help="""Overwrite existing variables in files
-                                """,
+        help="Overwrite existing variables in files",
     )
     parser.add_argument(
-        "--serial", action="store_true", help="""Do not use mpi"""
+        "--serial", action="store_true", help="Do not use mpi"
     )
     parser.add_argument(
         "--method",
@@ -115,7 +114,7 @@ def interpolator(
     inputfiles: List[Path],
     outputdir: Path,
     varnames: Iterable[str],
-    force: bool,
+    force: bool = False,
     method: str = "FineToCoarse",
 ):
     if method not in ("FineToCoarse", "nearest"):

--- a/src/bitsea/Sat/interpolator.py
+++ b/src/bitsea/Sat/interpolator.py
@@ -118,7 +118,7 @@ varnames: Iterable[str],
 force = bool,
 method : str = "FineToCoarse",
 ):
-
+    assert method in ["FineToCoarse","nearest"]
     maskIn = getattr(masks, inmesh)
 
     if not serial:
@@ -208,7 +208,7 @@ method : str = "FineToCoarse",
                     maskIn,
                     TheMask
                     )
-            else:
+            if method == "FineToCoarse":
                 Mout, usedPoints = interp2d.interp_2d_by_cells_slices(
                     Mfine,
                     TheMask,

--- a/src/bitsea/Sat/sat_check_QI.py
+++ b/src/bitsea/Sat/sat_check_QI.py
@@ -1,154 +1,189 @@
 import argparse
-from bitsea.utilities.argparse_types import some_among
+from pathlib import Path
+from sys import exit as sys_exit
+from typing import Iterable
+from typing import List
+
+import numpy as np
+from bitsea.commons.time_interval import TimeInterval
+from bitsea.commons.Timelist import TimeList
+from bitsea.postproc import masks
+from bitsea.Sat import SatManager as Sat
 from bitsea.utilities.argparse_types import existing_dir_path
+from bitsea.utilities.argparse_types import some_among
+from bitsea.utilities.mpi_serial_interface import get_mpi_communicator
 
 
 def argument():
-    parser = argparse.ArgumentParser(description = '''
-    Apply check based on QI provided by OCTAC
-    Produces CHECKED files for each date at satellite resolution.
-    QI = (value - ClimatologyMedianData)/ClimatologyStandardDeviation
+    parser = argparse.ArgumentParser(
+        description="""
+            Apply check based on QI provided by OCTAC
+            Produces CHECKED files for each date at satellite resolution.
+            QI = (value - ClimatologyMedianData)/ClimatologyStandardDeviation
 
-    ''',
-    formatter_class=argparse.ArgumentDefaultsHelpFormatter
+            """,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument(   '--origdir', '-i',
-                                type = existing_dir_path,
-                                required = True,
-                                help = ''' ORIG sat directory'''
-                                )
+    parser.add_argument(
+        "--origdir",
+        "-i",
+        type=existing_dir_path,
+        required=True,
+        help="ORIG sat directory",
+    )
 
-    parser.add_argument(   '--checkdir', '-o',
-                                type = existing_dir_path,
-                                required = True,
-                                help = ''' Base for CHECKED sat directory'''
-                                )
+    parser.add_argument(
+        "--checkdir",
+        "-o",
+        type=existing_dir_path,
+        required=True,
+        help="Base for CHECKED sat directory",
+    )
 
-    parser.add_argument(   '--mesh', '-m',
-                                type = str,
-                                required = True,
-                                choices = ['SatOrigMesh','V4mesh','V1mesh','KD490mesh','SAT1km_mesh', 'Mesh24'],
-                                help = ''' Name of the mesh of sat ORIG and used to dump checked data.'''
-                                )
-    parser.add_argument(   '--varnames', '-v',
-                                type = some_among(['CHL','KD490','DIATO','NANO','PICO', 'DINO','RRS412','RRS443','RRS490','RRS510','RRS555','RRS670']),
-                                required = True,
-                                help = '''Var name, corresponding to P_l, kd490, P1l, P2l P3l, P4l'''
-                                )
-    parser.add_argument(   '--force', '-f',
-                                action='store_true',
-                                help = """Overwrite existing variables in files
-                                """)
-    parser.add_argument(   '--QI',
-                                required=True,
-                                type=str,
-                                help = """QI threshold, usually 2, 2.5 or 3
-                                """)
-    parser.add_argument(   '--Kd_min',
-                                required=False,
-                                type=str,
-                                default="0.021",
-                                help = '''Kd minimum value threshold''')
-    parser.add_argument(   '--serial',
-                                action='store_true',
-                                help = '''Do not use mpi''')
-
+    parser.add_argument(
+        "--mesh",
+        "-m",
+        type=str,
+        required=True,
+        choices=[
+            "SatOrigMesh",
+            "V4mesh",
+            "V1mesh",
+            "KD490mesh",
+            "SAT1km_mesh",
+            "Mesh24",
+        ],
+        help="Name of the mesh of sat ORIG and used to dump checked data.",
+    )
+    parser.add_argument(
+        "--varnames",
+        "-v",
+        type=some_among(
+            [
+                "CHL",
+                "KD490",
+                "DIATO",
+                "NANO",
+                "PICO",
+                "DINO",
+                "RRS412",
+                "RRS443",
+                "RRS490",
+                "RRS510",
+                "RRS555",
+                "RRS670",
+            ]
+        ),
+        required=True,
+        help="Var name, corresponding to P_l, kd490, P1l, P2l P3l, P4l",
+    )
+    parser.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        help="Overwrite existing variables in files",
+    )
+    parser.add_argument(
+        "--QI",
+        required=True,
+        type=str,
+        help="QI threshold, usually 2, 2.5 or 3",
+    )
+    parser.add_argument(
+        "--Kd_min",
+        required=False,
+        type=str,
+        default="0.021",
+        help="Kd minimum value threshold",
+    )
+    parser.add_argument("--serial", action="store_true", help="Do not use mpi")
 
     return parser.parse_args()
 
 
 args = argument()
 
-from pathlib import Path
-from typing import List, Iterable
-from bitsea.commons.Timelist import TimeList
-from bitsea.commons.time_interval import TimeInterval
-from bitsea.postproc import masks
-import numpy as np
-from bitsea.Sat import SatManager as Sat
-from bitsea.utilities.mpi_serial_interface import get_mpi_communicator
-from sys import exit
 
-
-def sat_check(*,
-inputfiles : Iterable[Path],
-outputdir: Path,
-mesh: str,
-varnames : List[str],
-QI : float,
-Kd_min: float = float(0.021),
-force : bool = False,
-serial : bool = False,
-) -> List[Path] :
+def sat_check(
+    *,
+    inputfiles: Iterable[Path],
+    outputdir: Path,
+    mesh: str,
+    varnames: List[str],
+    QI: float,
+    Kd_min: float = float(0.021),
+    force: bool = False,
+    serial: bool = False,
+) -> List[Path]:
     if not serial:
-        import mpi4py.MPI
-
+        pass
 
     comm = get_mpi_communicator()
-    rank  = comm.Get_rank()
-    nranks =comm.size
-
+    rank = comm.Get_rank()
+    nranks = comm.size
 
     CHECKDIR = outputdir
     THRESHOLD = QI
 
-    maskSat = getattr(masks,mesh)
+    maskSat = getattr(masks, mesh)
 
-    checkedFileList=[CHECKDIR / f.name for f in inputfiles]
+    checkedFileList = [CHECKDIR / f.name for f in inputfiles]
 
     for filename in inputfiles[rank::nranks]:
-
         outfile = CHECKDIR / filename.name
 
         for varname in varnames:
-
             writing_mode = Sat.writing_mode(outfile)
 
-            condition_to_write = not Sat.exist_valid_variable(varname,outfile)
-            if force: condition_to_write=True
-            if not condition_to_write: continue
+            condition_to_write = not Sat.exist_valid_variable(varname, outfile)
+            if force:
+                condition_to_write = True
+            if not condition_to_write:
+                continue
 
-
-            if varname in ["DIATO","NANO","PICO","DINO"]:
+            if varname in ["DIATO", "NANO", "PICO", "DINO"]:
                 QI = Sat.readfromfile(filename, "QI_CHL")
             else:
                 QI = Sat.readfromfile(filename, "QI_" + varname)
-            VALUES = Sat.readfromfile(filename,varname)
+            VALUES = Sat.readfromfile(filename, varname)
 
-            if varname == 'KD490':
+            if varname == "KD490":
                 # VALUES[(VALUES<Kd_min) & (VALUES>0)] = Kd_min
-                VALUES[(VALUES<Kd_min) & (VALUES>0)] = Sat.fillValue   # Filter out values below Kd490_min threshold
+                VALUES[(VALUES < Kd_min) & (VALUES > 0)] = (
+                    Sat.fillValue
+                )  # Filter out values below Kd490_min threshold
 
-            bad = np.abs(QI) > THRESHOLD # 2.0
+            bad = np.abs(QI) > THRESHOLD  # 2.0
             VALUES[bad] = Sat.fillValue
             print(outfile, varname, flush=True)
-            Sat.dumpGenericfile(outfile, VALUES, varname, mesh=maskSat,mode=writing_mode)
+            Sat.dumpGenericfile(
+                outfile, VALUES, varname, mesh=maskSat, mode=writing_mode
+            )
     return checkedFileList
-
-
 
 
 def main():
     args = argument()
 
-
-    Timestart="19501231"
-    Time__end="20500101"
-    TI = TimeInterval(Timestart,Time__end,"%Y%m%d")
-    TL_orig = TimeList.fromfilenames(TI, args.origdir ,"*.nc",prefix='',dateformat='%Y%m%d')
-
+    Timestart = "19501231"
+    Time__end = "20500101"
+    TI = TimeInterval(Timestart, Time__end, "%Y%m%d")
+    TL_orig = TimeList.fromfilenames(
+        TI, args.origdir, "*.nc", prefix="", dateformat="%Y%m%d"
+    )
 
     sat_check(
         inputfiles=TL_orig.filelist,
         outputdir=args.checkdir,
         mesh=args.mesh,
         varnames=args.varnames,
-        QI = float(args.QI),
-        Kd_min = float(args.Kd_min),
-        force = args.force,
+        QI=float(args.QI),
+        Kd_min=float(args.Kd_min),
+        force=args.force,
         serial=args.serial,
     )
     return 0
 
+
 if __name__ == "__main__":
-    exit(main())
+    sys_exit(main())

--- a/src/bitsea/Sat/sat_check_QI.py
+++ b/src/bitsea/Sat/sat_check_QI.py
@@ -110,11 +110,7 @@ def sat_check(
     qi_threshold: float,
     Kd_min: float = 0.021,
     force: bool = False,
-    serial: bool = False,
 ) -> List[Path]:
-    if not serial:
-        pass
-
     comm = get_mpi_communicator()
     rank = comm.Get_rank()
     nranks = comm.size
@@ -159,6 +155,10 @@ def sat_check(
 def main():
     args = argument()
 
+    if not args.serial:
+        # noinspection PyUnresolvedReferences
+        import mpi4py.MPI
+
     time_start = "19501231"
     time_end = "20500101"
     TI = TimeInterval(time_start, time_end, "%Y%m%d")
@@ -174,7 +174,6 @@ def main():
         qi_threshold=float(args.QI),
         Kd_min=float(args.Kd_min),
         force=args.force,
-        serial=args.serial,
     )
     return 0
 


### PR DESCRIPTION
Refactoring
src/bitsea/Sat/sat_check_QI.py
src/bitsea/Sat/aveSat.py
src/bitsea/Sat/interpolator.py

in order to expose functions accepting and returning lists of filenames