### PR TITLE
79 new varmod poc

### DIFF
--- a/src/bitsea/validation/deliverables/metrics.py
+++ b/src/bitsea/validation/deliverables/metrics.py
@@ -37,12 +37,7 @@ def MLD(Temperature, Salinity, Pres, insitu_T=False):
     It resurns also DENSITY (SIGMA) and POTENTIAL DENSITY (SIGMA THETA)
     """
     th = 10  # threshold of depth minimum
-    i_less_than_10 = Pres < th
-    i_10 = (
-        i_less_than_10[-1] + 1
-    )  # (this is the index corresponding approx ~10m of the zlevel array)
-    # NO IT IS NOT! THIS IS:
-    #i_10 = np.abs(Pres - th).argmin()
+    i_10 = np.abs(Pres - th).argmin()
     T = Temperature
     S = Salinity
     # if T is in-situ (e.g. float data) convert to potential temperature 
@@ -51,7 +46,7 @@ def MLD(Temperature, Salinity, Pres, insitu_T=False):
     D1000 = Pres[
         (Pres < 1000) & (Pres > th)
     ]  # CONSIDER VALUES the reference level at 10m (de Boyer-Montegut 2004)
-    bitsea/validation/deliverablesT1000 = T[(Pres < 1000) & (Pres > th)]
+    T1000 = T[(Pres < 1000) & (Pres > th)]
     S1000 = S[(Pres < 1000) & (Pres > th)]
     Dens1000 = sw.dens(S1000, T1000, D1000) - 1000  # DENSITY # SIGMA
     PDens1000 = (

--- a/src/bitsea/validation/deliverables/metrics.py
+++ b/src/bitsea/validation/deliverables/metrics.py
@@ -30,7 +30,7 @@ def find_DCM(Chl_profile, zlev):
     return CM, DCM
 
 
-def MLD(Temperature, Salinity, Pres):
+def MLD(Temperature, Salinity, Pres, insitu_T=False):
     """Calculation of Mixed Layer Depth based on temperature difference of 0.2
     mld is defined as the level where the difference of temperature with respect the reference level of 10m
     is of 0.2C
@@ -41,15 +41,17 @@ def MLD(Temperature, Salinity, Pres):
     i_10 = (
         i_less_than_10[-1] + 1
     )  # (this is the index corresponding approx ~10m of the zlevel array)
-    i_10 = (
-        i_less_than_10[-1] + 1
-    )  # (this is the index corresponding approx ~10m of the zlevel array)
+    # NO IT IS NOT! THIS IS:
+    #i_10 = np.abs(Pres - th).argmin()
     T = Temperature
     S = Salinity
+    # if T is in-situ (e.g. float data) convert to potential temperature 
+    if insitu_T: 
+        T = sw.ptmp(S, T, Pres)
     D1000 = Pres[
         (Pres < 1000) & (Pres > th)
     ]  # CONSIDER VALUES the reference level at 10m (de Boyer-Montegut 2004)
-    T1000 = T[(Pres < 1000) & (Pres > th)]
+    bitsea/validation/deliverablesT1000 = T[(Pres < 1000) & (Pres > th)]
     S1000 = S[(Pres < 1000) & (Pres > th)]
     Dens1000 = sw.dens(S1000, T1000, D1000) - 1000  # DENSITY # SIGMA
     PDens1000 = (


### PR DESCRIPTION
solves #79 

in instruments.superfloat replaces BGC-Argo bbp700 to POC conversion from Bellacicco 2019 with the one from Galì 2022. 

also in validation.deliverables.metrics, now the MLD function can optionally work on in-situ temperature (as with Argo data), and incorporated the fix from #80 