### PR TITLE
Improves method `plot` of basins

### DIFF
--- a/src/bitsea/basins/basin.py
+++ b/src/bitsea/basins/basin.py
@@ -197,7 +197,10 @@ class SimplePolygonalBasin(SimpleBasin):
         fill=True,
         transform=None,
     ):
-        patch_kwargs = {"color": color, "alpha": alpha, "fill": fill}
+        if fill:
+            patch_kwargs = {"facecolor": color, "edgecolor": "none", "alpha": alpha, "fill": fill}
+        else:
+            patch_kwargs = {"facecolor": "none", "edgecolor": color, "alpha": alpha, "fill": fill}
         if zorder is not None:
             patch_kwargs["zorder"] = zorder
         if transform is not None:


### PR DESCRIPTION
This pull request improves the method `plot` of the basins, by adding some new features.

* Some flags have been renamed to be coherent with the ones that matplotlib uses
* Added the possibility to specify the z-order of each basin plot
* Now polygonal basins use their coordinate to draw the plot instead of using the general routine
* Composed basins' `plot` method now calls the `plot` method of each sub-basin

**Breaking API changes**:
* `axes` parameter renamed to `axis`.
* `filled` parameter renamed to `fill`.

**Return values**:
* `SimplePolygonalBasin.plot` now returns a PathPatch.
* `ComposedBasin.plot` returns None (plots sub-elements).
* `Basin.plot` continues to return the matplotlib contour object.

