### PR TITLE
Polygons now are curvilinear when using cartopy projections

### DIFF
--- a/src/bitsea/basins/basin.py
+++ b/src/bitsea/basins/basin.py
@@ -1,15 +1,19 @@
 # Copyright (c) 2015 eXact Lab srl
 # Author: Stefano Piani <stefano.piani@exact-lab.it>
 import importlib
+from collections.abc import Sequence
 from inspect import currentframe
+from typing import Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.colors import LinearSegmentedColormap
 from matplotlib.patches import PathPatch
+from matplotlib.path import Path
 
 from bitsea.basins.region import EmptyRegion
 from bitsea.basins.region import Region
+from bitsea.commons.geodistances import compute_great_circle_distance
 
 
 # This is the default module for the basins, i.e. the basins of this
@@ -164,7 +168,7 @@ class Basin(object):
             lon_grid, lat_grid, inside_domain, [0.1, 1], alpha=alpha, **kwargs
         )
 
-        return current_plot
+        return (current_plot,)
 
 
 class SimpleBasin(Basin):
@@ -180,6 +184,58 @@ class SimpleBasin(Basin):
 
 
 class SimplePolygonalBasin(SimpleBasin):
+    @staticmethod
+    def _densify_polygonal(
+        coords: Sequence[Tuple[float, float]], resolution=5000
+    ) -> Path:
+        """
+        Transform a sequence of coordinates into a Path object
+
+        Given a sequence of coordinates (lon, lat), this function returns a
+        Path object: the region of the plane that is delimited by the segments
+        defined by the coordinates.
+
+        This function is intended to be used to draw polygons on projected
+        Cartopy maps; in this case, the segments must follow the projection of
+        the plot and not be rendered as straight lines. This is obtained by
+        "densifying" the points on the boundaries of the polygon. In this way,
+        the segments are rendered as a sequence of short straight lines on the
+        map, but the actual path followed by the polygon is more accurate.
+
+        Args:
+            coords: a sequence of (lon, lat) tuples. The last point is expected
+                to be equal to the first one (the path is closed)
+            resolution: this is the distance (in metres) between two
+                consecutive points on the path of the segment. There will be no
+                segments longer than this distance.
+
+        Returns:
+            A Path object.
+        """
+        densified_lon = [coords[0][0]]
+        densified_lat = [coords[0][1]]
+        for a, b in zip(coords[:-1], coords[1:]):
+            point_distance = compute_great_circle_distance(
+                lat1=a[1], lon1=a[0], lat2=b[1], lon2=b[0]
+            )
+            if point_distance < resolution:
+                densified_lon.append(b[0])
+                densified_lat.append(b[1])
+                continue
+
+            edge_points = int(np.ceil(point_distance / resolution)) + 1
+            densified_lon.extend(np.linspace(a[0], b[0], edge_points)[1:])
+            densified_lat.extend(np.linspace(a[1], b[1], edge_points)[1:])
+
+        # Create a path object
+        codes = [Path.LINETO] * len(densified_lon)
+        codes[0] = Path.MOVETO
+        codes[-1] = Path.CLOSEPOLY
+
+        densified_coords = np.column_stack([densified_lon, densified_lat])
+
+        return Path(densified_coords, codes)
+
     @property
     def borders(self):
         return self.region.borders
@@ -198,22 +254,35 @@ class SimplePolygonalBasin(SimpleBasin):
         transform=None,
     ):
         if fill:
-            patch_kwargs = {"facecolor": color, "edgecolor": "none", "alpha": alpha, "fill": fill}
+            patch_kwargs = {
+                "facecolor": color,
+                "edgecolor": "none",
+                "alpha": alpha,
+                "fill": fill,
+            }
         else:
-            patch_kwargs = {"facecolor": "none", "edgecolor": color, "alpha": alpha, "fill": fill}
+            patch_kwargs = {
+                "facecolor": "none",
+                "edgecolor": color,
+                "alpha": alpha,
+                "fill": fill,
+            }
         if zorder is not None:
             patch_kwargs["zorder"] = zorder
         if transform is not None:
             patch_kwargs["transform"] = transform
 
-        patch = PathPatch(self.region.path, **patch_kwargs)
+        coords = self.region.borders
+        path = self._densify_polygonal(coords)
+
+        patch = PathPatch(path, **patch_kwargs)
 
         if axis is None:
             axis = plt.gca()
 
         axis.add_patch(patch)
 
-        return patch
+        return (patch,)
 
 
 class SimpleBathymetricBasin(SimpleBasin):
@@ -246,8 +315,9 @@ class ComposedBasin(Basin):
         fill=True,
         transform=None,
     ):
+        plots = []
         for basin in self.basin_list:
-            basin.plot(
+            current_plot = basin.plot(
                 lon_window=lon_window,
                 lat_window=lat_window,
                 lon_points=lon_points,
@@ -259,6 +329,9 @@ class ComposedBasin(Basin):
                 fill=fill,
                 transform=transform,
             )
+            plots.extend(current_plot)
+
+        return tuple(plots)
 
     def is_inside(self, lon, lat):
         if len(self.basin_list) == 0:


### PR DESCRIPTION
On the current master, Polygonal basins render incorrectly on Cartopy projections because they are rendered with straight lines, even if using a projection where their sides should be  curvilinear. This pull request fixes this problem.

Now the boundary of the polygon is split into small straight lines of length < 5km, and each vertex of each line is projected.
In this way, we obtain a good representation of a curved line.

## Changes

**Core algorithm** (`SimplePolygonalBasin._densify_polygonal`):
- Subdivides polygon edges into segments ≤5km using great circle distance
- Generates matplotlib Path with densified vertices
- Ensures Cartopy projection transforms approximate intended curves

**API updates**:
- All Basin `plot()` methods now return tuples for consistency
- `SimplePolygonalBasin.plot()` uses densified paths instead of `region.path`
- `ComposedBasin.plot()` aggregates sub-basin plots

**Imports**:
- `collections.abc.Sequence`, `typing.Tuple` for type hints
- `matplotlib.path.Path` for path construction
- `bitsea.commons.geodistances.compute_great_circle_distance` for segment subdivision
