### PR TITLE
usage of numpy.asarray

### DIFF
--- a/src/bitsea/Float/dump_index.py
+++ b/src/bitsea/Float/dump_index.py
@@ -97,7 +97,7 @@ def file_header_content(filename,VARLIST, avail_params=None):
         ncIN.close()
         return
 
-    ref  = np.array(ncIN.variables['REFERENCE_DATE_TIME']).tobytes().decode()
+    ref  = np.asarray(ncIN.variables['REFERENCE_DATE_TIME']).tobytes().decode()
     juld = int (ncIN.variables['JULD'][0])
     d=datetime.datetime.strptime(ref,'%Y%m%d%H%M%S')
     Time =  d+datetime.timedelta(days=juld)


### PR DESCRIPTION
removes a Deprecation Warning message from np.array
```
DeprecationWarning: __array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments. To learn more, see the migration guide https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword
  ref  = np.array(ncIN.variables['REFERENCE_DATE_TIME']).tobytes().decode()
```